### PR TITLE
allow trailing section argument

### DIFF
--- a/autoload/manpager.vim
+++ b/autoload/manpager.vim
@@ -11,7 +11,7 @@ function! s:args(section, page) abort " {{{
   if empty(a:section)
     return [a:page]
   else
-    return [g:manpager#man_sect_arg, a:section, a:page]
+    return [a:section, a:page]
   endif
 endfunction " }}}
 function! s:remove_backspaces() abort " {{{

--- a/ftplugin/man.vim
+++ b/ftplugin/man.vim
@@ -11,11 +11,11 @@ setlocal iskeyword+=\.,-
 
 nnoremap <buffer><silent> <Plug>(manpager-next-keyword)     :<C-u>call manpager#find_next_keyword()<CR>
 nnoremap <buffer><silent> <Plug>(manpager-previous-keyword) :<C-u>call manpager#find_previous_keyword()<CR>
-nnoremap <buffer><silent> <Plug>(manpager-open)             :<C-u>call manpager#open('', expand('<cword>'))<CR>
-xnoremap <buffer><silent> <Plug>(manpager-open)             :<C-u>call manpager#open('', '<C-R>=manpager#get_visual_selection()<CR>')<CR>
 nnoremap <buffer><silent> <Plug>(manpager-open-next)        :<C-u>call manpager#history#next()<CR>
 nnoremap <buffer><silent> <Plug>(manpager-open-previous)    :<C-u>call manpager#history#previous()<CR>
 nnoremap <buffer><silent> <Plug>(manpager-close) :<C-u>q<CR>
+nnoremap <buffer><silent> <Plug>(manpager-open)             :<C-u>Man<CR>
+xnoremap <buffer><silent> <Plug>(manpager-open)             :<C-u>Man <C-R>=manpager#get_visual_selection()<CR><CR>
 
 nmap <buffer><nowait> K             <Plug>(manpager-open)
 xmap <buffer><nowait> K             <Plug>(manpager-open)

--- a/plugin/manpager.vim
+++ b/plugin/manpager.vim
@@ -10,19 +10,22 @@ function! s:MANPAGER() abort
 endfunction
 function! s:MAN(...) abort
   if !a:0
-    call manpager#open('', expand('<cword>'))
+    let cWORD = expand('<cWORD>')
+    let pagesect_pattern = '\v[a-zA-Z-]+\(\w+\)'
+    let sect = ''
+    let page = matchstr(cWORD, pagesect_pattern)
   else
     let sect = (a:1 =~ '\v^((\d+(\+\d+|\w+)?)|(\w$))$' ? a:1 : '')
     let page = join(a:000[ (empty(sect) ? 0 : 1) :], '-')
-
-    if empty(sect)
-      let sectpattern = '\v\(\w+\)$'
-      let sect = substitute(matchstr(page, sectpattern),'\v[()]','','g')
-      let page = substitute(page, sectpattern,'','')
-    endif
-
-    call manpager#open(sect, page)
   endif
+
+  if empty(sect)
+    let sectpattern = '\v\(\w+\)$'
+    let sect = substitute(matchstr(page, sectpattern),'\v[()]','','g')
+    let page = substitute(page, sectpattern,'','')
+  endif
+
+  call manpager#open(sect, page)
 endfunction
 
 command! -nargs=0 MANPAGER call s:MANPAGER()

--- a/plugin/manpager.vim
+++ b/plugin/manpager.vim
@@ -12,8 +12,15 @@ function! s:MAN(...) abort
   if !a:0
     call manpager#open('', expand('<cword>'))
   else
-    let sect = a:1 =~ '\v\d+(\+\d+|\w+)?' ? a:1 : ''
+    let sect = (a:1 =~ '\v^((\d+(\+\d+|\w+)?)|(\w$))$' ? a:1 : '')
     let page = join(a:000[ (empty(sect) ? 0 : 1) :], '-')
+
+    if empty(sect)
+      let sectpattern = '\v\(\w+\)$'
+      let sect = substitute(matchstr(page, sectpattern),'\v[()]','','g')
+      let page = substitute(page, sectpattern,'','')
+    endif
+
     call manpager#open(sect, page)
   endif
 endfunction


### PR DESCRIPTION
Links are given in the format $PAGE($SECTION). With this commit, the `:Man` command, and consequently `K` in normal and visual mode, handles these correctly, as if given in the format `:Man $SECTION $PAGE`.
