### PR TITLE
Set `nocursorcolum` when `nocursorline` is set.

### DIFF
--- a/ftplugin/man.vim
+++ b/ftplugin/man.vim
@@ -7,6 +7,7 @@ setlocal tabstop=8
 setlocal nolist
 setlocal nospell
 setlocal nocursorline
+setlocal nocursorcolumn
 setlocal iskeyword+=\.,-
 
 nnoremap <buffer><silent> <Plug>(manpager-next-keyword)     :<C-u>call manpager#find_next_keyword()<CR>


### PR DESCRIPTION
I like how `nocursorline` is set when viewing man pages. I think this means `nocursorline` should be set as well to remove any vertical highlights a user has set.
