### PR TITLE
MANPAGER2: Avoid conflict with the stock MANPAGER

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ NeoBundle 'lambdalisue/vim-manpager'
 " neobundle.vim (Lazy)
 NeoBundleLazy 'lambdalisue/vim-manpager', {
         \ 'autoload': {
-        \   'commands': 'MANPAGER',
+        \   'commands': 'MANPAGER2',
         \}}
 ```
 
@@ -36,7 +36,7 @@ Usage
 To open vim via `man` command, use the following settings in your shell.
 
 ```
-$ export MANPAGER="vim -c MANPAGER -"
+$ export MANPAGER="vim -c MANPAGER2 -"
 $ man git
 ```
 

--- a/plugin/manpager.vim
+++ b/plugin/manpager.vim
@@ -33,7 +33,15 @@ function! s:MAN(...) abort
   call manpager#open(sect, page)
 endfunction
 
-command! -nargs=0 MANPAGER call s:MANPAGER()
+" `plugin/manpager.vim` from $VIMRUNTIME defines a `MANPAGER` command, so we
+" can not use the same name here.
+"
+" TODO Talk to Enno Nagel <ennonagel+vim@gmail.com>, who is the manpager.vim
+" maintainer, to see if there is a way to provide a custmization point,
+" allowing plugins to replace the stock MANPAGER implementation?
+"
+" command! -nargs=0 MANPAGER call s:MANPAGER()
+command! -nargs=0 MANPAGER2 call s:MANPAGER()
 command! -nargs=* Man      call s:MAN(<f-args>)
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Vim comes with a MANPAGER plugin in $VIMRUNTIME/plugin/manpager.vim.
$VIMRUNTIME plugin defines a MANPAGER command already.  Redefining the
same command could be error-prone.  And as of a recent update

    commit d592deb336523a5448779ee3d4bba80334cff1f7
    Author: Bram Moolenaar <Bram@vim.org>
    Date:   Fri Jun 17 15:42:40 2022 +0100

        Update runtime files

MANPAGER plugin in $VIMRUNTIME defines MANPAGER command without a
consideration of whether it already exists or not.  Effectively
generating an error on every startup if `vim-manpager` plugin is also
loaded.