### PR TITLE
:boom: Use `ASMANPAGER` instead to fix #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,17 @@
-vim-manpager
-===============================================================================
+# vim-manpager
+
 ![Version 0.1.0](https://img.shields.io/badge/version-0.1.0-yellow.svg?style=flat-square)
 ![Support Vim 7.4 or above](https://img.shields.io/badge/support-Vim%207.4%20or%20above-yellowgreen.svg?style=flat-square)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Doc](https://img.shields.io/badge/doc-%3Ah%20vim--manpager-orange.svg?style=flat-square)](doc/vim-manpager.txt)
 
-*vim-manpager* is plugin to use Vim as a MANPAGER.
+_vim-manpager_ is plugin to use Vim as a MANPAGER.
 It also improve the behavior of `:Man` command and mappings in `man` file.
 See [lambdalisue/vim-pager](https://github.com/lambdalisue/vim-pager) for PAGER.
 
 ![Screencast](http://g.recordit.co/nnvpuIKOKK.gif)
 
-
-Install
--------------------------------------------------------------------------------
+## Install
 
 ```vim
 " Vundle.vim
@@ -25,18 +23,16 @@ NeoBundle 'lambdalisue/vim-manpager'
 " neobundle.vim (Lazy)
 NeoBundleLazy 'lambdalisue/vim-manpager', {
         \ 'autoload': {
-        \   'commands': 'MANPAGER',
+        \   'commands': 'ASMANPAGER',
         \}}
 ```
 
-
-Usage
--------------------------------------------------------------------------------
+## Usage
 
 To open vim via `man` command, use the following settings in your shell.
 
 ```
-$ export MANPAGER="vim -c MANPAGER -"
+$ export MANPAGER="vim -c ASMANPAGER -"
 $ man git
 ```
 
@@ -50,12 +46,12 @@ behavior)
 
 In man buffer, you can use the following keymaps
 
-- `K`		Open the manual page for the word under the cursor
-- `Enter`	Open the manual page for the word under the cursor
-- `Ctrl-]`	Open the manual page for the word under the cursor
-- `2-LeftMouse`	Open the manual page for the word under the cursor
-- `Tab`		Open next manual page in the history
-- `Shift-Tab`	Open previous manual page in the history
-- `]t`		Find next keyword and move the cursor onto
-- `[t`		Find previous keyword and move the cursor onto
-- `q`		Close the manual page
+- `K` Open the manual page for the word under the cursor
+- `Enter` Open the manual page for the word under the cursor
+- `Ctrl-]` Open the manual page for the word under the cursor
+- `2-LeftMouse` Open the manual page for the word under the cursor
+- `Tab` Open next manual page in the history
+- `Shift-Tab` Open previous manual page in the history
+- `]t` Find next keyword and move the cursor onto
+- `[t` Find previous keyword and move the cursor onto
+- `q` Close the manual page

--- a/doc/vim-manpager.txt
+++ b/doc/vim-manpager.txt
@@ -40,7 +40,7 @@ plugin manager to install |vim-manpager| like:
 	" neobundle.vim (Lazy)
 	NeoBundleLazy 'lambdalisue/vim-manpager', {
 		\ 'autoload': {
-		\   'commands': 'MANPAGER',
+		\   'commands': 'ASMANPAGER',
 		\}}
 <
 If you are not using any vim plugin manager, you can copy the repository to
@@ -52,7 +52,7 @@ USAGE					*vim-manpager-usage*
 
 Add MANPAGER environment variable as
 >
-	$ export MANPAGER="vim -c MANPAGER -"
+	$ export MANPAGER="vim -c ASMANPAGER -"
 <
 Then 'man' command will use Vim as a MANPAGER.
 
@@ -89,7 +89,7 @@ INTERFACE				*vim-manpager-interface*
 ------------------------------------------------------------------------------
 COMMAND					*vim-manpager-command*
 
-:MANPAGER			   			*:MANPAGER*
+:ASMANPAGER			   			*:ASMANPAGER*
 
 	Enable MANPAGER mode on the current buffer.
 	It automatically remove unwilling backspace characters (^H) from the

--- a/plugin/manpager.vim
+++ b/plugin/manpager.vim
@@ -33,7 +33,7 @@ function! s:MAN(...) abort
   call manpager#open(sect, page)
 endfunction
 
-command! -nargs=0 MANPAGER call s:MANPAGER()
+command! -nargs=0 ASMANPAGER call s:MANPAGER()
 command! -nargs=* Man      call s:MAN(<f-args>)
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
I just couldn't be bothered to force Vim to fix the issue. Renaming is
enough, even it's a breaking change.
https://github.com/vim/vim/commit/d592deb336523a5448779ee3d4bba80334cff1f7